### PR TITLE
Add null check in DefaultUnityConstructorSelectorPolicy

### DIFF
--- a/source/Src/Unity-CoreClr/ObjectBuilderCustomization/DefaultUnityConstructorSelectorPolicy.cs
+++ b/source/Src/Unity-CoreClr/ObjectBuilderCustomization/DefaultUnityConstructorSelectorPolicy.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -30,13 +31,13 @@ namespace Unity.ObjectBuilder
             Guard.ArgumentNotNull(parameter, "parameter");
 
             // Resolve all DependencyAttributes on this parameter, if any
-            var attrs = parameter.GetCustomAttributes(false).OfType<DependencyResolutionAttribute>().ToList();
+            var attr = parameter.GetCustomAttributes(false)?.OfType<DependencyResolutionAttribute>().FirstOrDefault();
 
-            if (attrs.Count > 0)
+            if (attr != null)
             {
                 // Since this attribute is defined with MultipleUse = false, the compiler will
                 // enforce at most one. So we don't need to check for more.
-                return attrs[0].CreateResolver(parameter.ParameterType);
+                return attr.CreateResolver(parameter.ParameterType);
             }
 
             // No attribute, just go back to the container for the default for that type.


### PR DESCRIPTION
Note: the fix uses the new null-propagation operator, which requires C# 6 / VS2015 to compile. If this is an issue, I can change it to be compatible with C# 5.
