### PR TITLE
Nested generics support in Shorthand format of type for Configuration

### DIFF
--- a/source/Unity.Configuration/Src/ConfigurationHelpers/TypeNameInfo.cs
+++ b/source/Unity.Configuration/Src/ConfigurationHelpers/TypeNameInfo.cs
@@ -58,5 +58,50 @@ namespace Microsoft.Practices.Unity.Configuration.ConfigurationHelpers
                 return name;
             }
         }
+
+        public string FullNameWithNestedGenerics
+        {
+            get
+            {
+                string name = Name;
+                if (IsGenericType)
+                {
+                    if (IsOpenGeneric)
+                    {
+                        name += '`' + NumGenericParameters.ToString(CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        name += '[';
+
+                        for (int i = 0; i < NumGenericParameters; i++)
+                        {
+                            TypeNameInfo genericParameterInfo = GenericParameters[i];
+
+                            string genericParameter = genericParameterInfo.FullNameWithNestedGenerics;
+
+                            if (!string.IsNullOrEmpty(genericParameterInfo.AssemblyName))
+                                genericParameter = "[" + genericParameter + "]";
+
+                            name += genericParameter;
+
+                            if (i != NumGenericParameters - 1)
+                                name += ",";
+                        }
+
+                        name += ']';
+                    }
+                }
+                if (!string.IsNullOrEmpty(Namespace))
+                {
+                    name = Namespace + '.' + name;
+                }
+                if (!string.IsNullOrEmpty(AssemblyName))
+                {
+                    name = name + ", " + AssemblyName;
+                }
+                return name;
+            }
+        }
     }
 }

--- a/source/Unity.Configuration/Src/ConfigurationHelpers/TypeResolverImpl.cs
+++ b/source/Unity.Configuration/Src/ConfigurationHelpers/TypeResolverImpl.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Practices.Unity.Configuration.ConfigurationHelpers
                 {
                     foreach (var genericParamInfo in parseResult.GenericParameters)
                     {
-                        Type genericParam = ResolveType(genericParamInfo.FullName, false);
+                        Type genericParam = ResolveType(genericParamInfo.FullNameWithNestedGenerics, false);
                         if (genericParam == null)
                         {
                             return null;

--- a/source/Unity.Configuration/Tests/Unity.Configuration.Tests/When_ResolvingTypes.cs
+++ b/source/Unity.Configuration/Tests/Unity.Configuration.Tests/When_ResolvingTypes.cs
@@ -138,5 +138,29 @@ namespace Microsoft.Practices.Unity.Configuration.Tests
         {
             Assert.IsNull(typeResolver.ResolveType("Namespace.Type, Assembly", false));
         }
+
+        [TestMethod]
+        public void Then_ShorthandWithNestedGenericIsResolved()
+        {
+            Assert.AreSame(typeResolver.ResolveType("List[List[int]]", true), typeof(List<List<int>>));
+        }
+
+        [TestMethod]
+        public void Then_ShorthandWithNestedGenericAndMultipleParametersIsResolved()
+        {
+            Assert.AreSame(typeResolver.ResolveType("Func[List[int], string]", true), typeof(Func<List<int>, string>));
+        }
+
+        [TestMethod]
+        public void Then_ShorthandWith2NestedGenericIsResolved()
+        {
+            Assert.AreSame(typeResolver.ResolveType("List[List[List[int]]]", true), typeof(List<List<List<int>>>));
+        }
+
+        [TestMethod]
+        public void Then_ShorthandWith2NestedGenericAndAssemblyNameIsResolved()
+        {
+            Assert.AreSame(typeResolver.ResolveType("List[Func[[System.Collections.Generic.List[int], mscorlib], string]]", true), typeof(List<Func<List<int>, string>>));
+        }
     }
 }

--- a/source/Unity.Configuration/Tests/Unity.Configuration.Tests/When_ResolvingTypesWithoutNamespacesDefined.cs
+++ b/source/Unity.Configuration/Tests/Unity.Configuration.Tests/When_ResolvingTypesWithoutNamespacesDefined.cs
@@ -107,5 +107,11 @@ namespace Microsoft.Practices.Unity.Configuration.Tests
         {
             Assert.IsNull(typeResolver.ResolveType("Namespace.Type, Assembly", false));
         }
+
+        [TestMethod]
+        public void Then_ShorthandWithNestedGenericAndMultipleParametersIsResolved()
+        {
+            Assert.AreSame(typeResolver.ResolveType("System.Func[[System.Collections.Generic.List[int], mscorlib], System.Int64], mscorlib", true), typeof(Func<List<int>, long>));
+        }
     }
 }


### PR DESCRIPTION
Added support for describe generics params in nested gererics in Shorthand format of type for Configuration.

For example Func[List[int], string] must be resolved as Func<List<int>, string> (before it's resolved as Func<List`1, string>.

The problem was in TypeResolverImpl, when we are resolve genericParams, we are ignore internal genericParams (because FullName don't get them).
I add new property FullNameWithNestedGenerics for this case.

Also added some tests for this.
