### PR TITLE
Make ContainerRegistration's constructor public

### DIFF
--- a/source/Src/Unity-CoreClr/ContainerRegistration.cs
+++ b/source/Src/Unity-CoreClr/ContainerRegistration.cs
@@ -13,7 +13,7 @@ namespace Unity
     {
         private readonly NamedTypeBuildKey buildKey;
 
-        internal ContainerRegistration(Type registeredType, string name, IPolicyList policies)
+        public ContainerRegistration(Type registeredType, string name, IPolicyList policies)
         {
             this.buildKey = new NamedTypeBuildKey(registeredType, name);
             MappedToType = GetMappedType(policies);


### PR DESCRIPTION
This class part of Unity's public interface. Right now there can be no other implementation of `IUnityContainer` because this class cannot be constructed (except via reflection).
[Issue on CodePlex](https://unity.codeplex.com/workitem/12724)
