### PR TITLE
Avoid StackOverflow exception if someone registers a container in its…

### DIFF
--- a/source/Src/Unity-CoreClr/UnityContainer.cs
+++ b/source/Src/Unity-CoreClr/UnityContainer.cs
@@ -469,6 +469,8 @@ namespace Unity
             GC.SuppressFinalize(this); // Shut FxCop up
         }
 
+        private bool inDispose = false;
+
         /// <summary>
         /// Dispose this container instance.
         /// </summary>
@@ -478,8 +480,12 @@ namespace Unity
         /// method, false if being called from a finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && !inDispose)
             {
+                // Avoid infinite loop when someone
+                //  registers something which would end up 
+                //  disposing this container (e.g. container.RegisterInsance(container))
+                inDispose = true;
                 if (lifetimeContainer != null)
                 {
                     lifetimeContainer.Dispose();

--- a/source/Src/Unity-CoreClr/UnityContainer.cs
+++ b/source/Src/Unity-CoreClr/UnityContainer.cs
@@ -469,8 +469,6 @@ namespace Unity
             GC.SuppressFinalize(this); // Shut FxCop up
         }
 
-        private bool inDispose = false;
-
         /// <summary>
         /// Dispose this container instance.
         /// </summary>
@@ -480,16 +478,16 @@ namespace Unity
         /// method, false if being called from a finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing && !inDispose)
+            if (disposing)
             {
-                // Avoid infinite loop when someone
-                //  registers something which would end up 
-                //  disposing this container (e.g. container.RegisterInsance(container))
-                inDispose = true;
                 if (lifetimeContainer != null)
                 {
-                    lifetimeContainer.Dispose();
+                    // Avoid infinite loop when someone
+                    //  registers something which would end up 
+                    //  disposing this container (e.g. container.RegisterInsance(container))
+                    LifetimeContainer lifetimeContainerCopy = lifetimeContainer;
                     lifetimeContainer = null;
+                    lifetimeContainerCopy.Dispose();
 
                     if (parent != null && parent.lifetimeContainer != null)
                     {

--- a/source/Tests/Unity.Tests/UnityContainerFixture.cs
+++ b/source/Tests/Unity.Tests/UnityContainerFixture.cs
@@ -337,6 +337,15 @@ namespace Unity.Tests
         }
 
         [Fact]
+        public void DisposingContainerDoesNotRecursivelyDisposeSelf()
+        {
+            IUnityContainer container = new UnityContainer();
+            container.RegisterInstance(container);
+            // This line should not throw a StackOverflow
+            container.Dispose();
+        }
+
+        [Fact]
         public void ContainerDefaultsToInstanceOwnership()
         {
             DisposableObject o = new DisposableObject();


### PR DESCRIPTION
Noticed that when I (foolishly) registered a container with itself as an instance and then disposed it I got a StackOverflow exception as it recursively tried to dispose itself. Minimum example:

```
var container = new UnityContainer();
container.RegisterInstance(container);
container.Dispose(); // This throws a StackOverflow
```

People should not be registering a container with itself I admit, but a (difficult to trace) StackOverflow when they do is quite unfortunate! :)

I've fixed this by making each container instance remember if it's in the middle of being disposed to avoid infinite recursion.

Unit test added in what seemed like the most appropriate place.

My first (ever) PR so apologies if I've missed anything out! Not sure if there was some other suite other than the unit tests I should have run before committing - FxCop?
